### PR TITLE
Add message when no violation has been detected

### DIFF
--- a/src/CLI/Check.php
+++ b/src/CLI/Check.php
@@ -92,6 +92,8 @@ class Check extends Command
             return self::ERROR_CODE;
         }
 
+        $this->printNoViolationsDetectedMessage($output);
+
         return self::SUCCESS_CODE;
     }
 

--- a/src/CLI/Check.php
+++ b/src/CLI/Check.php
@@ -150,4 +150,8 @@ class Check extends Command
         $output->writeln('<error>ERROR ON PARSING THESE FILES:</error>');
         $output->writeln(sprintf('%s', $parsingErrors->toString()));
     }
+
+    private function printNoViolationsDetectedMessage(OutputInterface $output): void {
+        $output->writeln('<info>NO VIOLATIONS DETECTED!</info>');
+    }
 }


### PR DESCRIPTION
# Description

Adds a message at the end of the output that tells that no violation has been detected in the code.


## Type of change

New feature (non-breaking change which adds functionality)

EDIT: closed in favor of [PR #2](https://github.com/mloru/arkitect/pull/2) 